### PR TITLE
Update dependencies + more stuff

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+inherit_from:
+  - default.yml

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in sequra-style.gemspec
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sequra-style (0.1.0)
+    sequra-style (0.1.1)
       rubocop (~> 0.93.1)
       rubocop-performance (~> 1.8.1)
       rubocop-rails (~> 2.8.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,10 +2,10 @@ PATH
   remote: .
   specs:
     sequra-style (0.1.0)
-      rubocop (~> 1.2)
+      rubocop (~> 0.93.1)
       rubocop-performance (~> 1.8.1)
       rubocop-rails (~> 2.8.1)
-      rubocop-rspec (~> 2.0.0)
+      rubocop-rspec (~> 1.44.1)
 
 GEM
   remote: https://rubygems.org/
@@ -29,13 +29,13 @@ GEM
     rake (13.0.1)
     regexp_parser (1.8.2)
     rexml (3.2.4)
-    rubocop (1.2.0)
+    rubocop (0.93.1)
       parallel (~> 1.10)
       parser (>= 2.7.1.5)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8)
       rexml
-      rubocop-ast (>= 1.0.1)
+      rubocop-ast (>= 0.6.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
     rubocop-ast (1.1.1)
@@ -47,9 +47,9 @@ GEM
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 0.87.0)
-    rubocop-rspec (2.0.0)
-      rubocop (~> 1.0)
-      rubocop-ast (>= 1.1.0)
+    rubocop-rspec (1.44.1)
+      rubocop (~> 0.87)
+      rubocop-ast (>= 0.7.1)
     ruby-progressbar (1.10.1)
     thread_safe (0.3.6)
     tzinfo (1.2.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,69 @@
+PATH
+  remote: .
+  specs:
+    sequra-style (0.1.0)
+      rubocop (~> 1.2)
+      rubocop-performance (~> 1.8.1)
+      rubocop-rails (~> 2.8.1)
+      rubocop-rspec (~> 2.0.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (6.0.3.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2, >= 2.2.2)
+    ast (2.4.1)
+    concurrent-ruby (1.1.7)
+    i18n (1.8.5)
+      concurrent-ruby (~> 1.0)
+    minitest (5.14.2)
+    parallel (1.20.0)
+    parser (2.7.2.0)
+      ast (~> 2.4.1)
+    rack (2.2.3)
+    rainbow (3.0.0)
+    rake (13.0.1)
+    regexp_parser (1.8.2)
+    rexml (3.2.4)
+    rubocop (1.2.0)
+      parallel (~> 1.10)
+      parser (>= 2.7.1.5)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8)
+      rexml
+      rubocop-ast (>= 1.0.1)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-ast (1.1.1)
+      parser (>= 2.7.1.5)
+    rubocop-performance (1.8.1)
+      rubocop (>= 0.87.0)
+      rubocop-ast (>= 0.4.0)
+    rubocop-rails (2.8.1)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 0.87.0)
+    rubocop-rspec (2.0.0)
+      rubocop (~> 1.0)
+      rubocop-ast (>= 1.1.0)
+    ruby-progressbar (1.10.1)
+    thread_safe (0.3.6)
+    tzinfo (1.2.8)
+      thread_safe (~> 0.1)
+    unicode-display_width (1.7.0)
+    zeitwerk (2.4.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 2.1.4)
+  rake (~> 13.0.1)
+  sequra-style!
+
+BUNDLED WITH
+   2.1.4

--- a/README.md
+++ b/README.md
@@ -5,19 +5,17 @@ Inspired by Percy Blog [post](https://blog.percy.io/share-rubocop-rules-across-a
 
 ## Installation
 
-Add this line to your application's Gemfile:
+Add this line to your application's Gemfile (we need to point to GitHub since it's not published):
 
 ```ruby
-gem "sequra-style"
+gem "sequra-style", git: "https://github.com/sequra/sequra-style", require: false
 ```
 
 And then execute:
 
-    $ bundle
-
-Or install it yourself as:
-
-    $ gem install sequra-style
+```shell
+$ bundle install
+```
 
 ## Usage
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,1 @@
 require "bundler/gem_tasks"
-task :default => :spec

--- a/default.yml
+++ b/default.yml
@@ -11,6 +11,7 @@ AllCops:
     - "**/vendor/**/*"
     - "**/node_modules/**/*"
     - "local_files/**/*"
+  NewCops: disable
 
 Performance:
   Enabled: true
@@ -18,9 +19,6 @@ Performance:
     - "**/spec/**/*"
 
 Rails:
-  Enabled: true
-
-RSpec:
   Enabled: true
 
 # Prefer assert_not over assert !

--- a/default.yml
+++ b/default.yml
@@ -230,3 +230,6 @@ RSpec/ExampleLength:
 
 RSpec/MultipleExpectations:
   Enabled: false
+
+RSpec/NestedGroups:
+  Enabled: false

--- a/lib/sequra/style/version.rb
+++ b/lib/sequra/style/version.rb
@@ -1,5 +1,5 @@
 module Sequra
   module Style
-    VERSION = "0.1.0"
+    VERSION = "0.1.1"
   end
 end

--- a/sequra-style.gemspec
+++ b/sequra-style.gemspec
@@ -32,11 +32,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.84.0"
-  spec.add_dependency "rubocop-performance", "~> 1.5.2"
-  spec.add_dependency "rubocop-rails", "~> 2.4.2"
-  spec.add_dependency "rubocop-rspec", "~> 1.38.1"
+  spec.add_dependency "rubocop", "~> 1.2"
+  spec.add_dependency "rubocop-performance", "~> 1.8.1"
+  spec.add_dependency "rubocop-rails", "~> 2.8.1"
+  spec.add_dependency "rubocop-rspec", "~> 2.0.0"
 
-  spec.add_development_dependency "bundler", "~> 1.17"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", "~> 2.1.4"
+  spec.add_development_dependency "rake", "~> 13.0.1"
 end

--- a/sequra-style.gemspec
+++ b/sequra-style.gemspec
@@ -32,10 +32,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 1.2"
+  spec.add_dependency "rubocop", "~> 0.93.1"
   spec.add_dependency "rubocop-performance", "~> 1.8.1"
   spec.add_dependency "rubocop-rails", "~> 2.8.1"
-  spec.add_dependency "rubocop-rspec", "~> 2.0.0"
+  spec.add_dependency "rubocop-rspec", "~> 1.44.1"
 
   spec.add_development_dependency "bundler", "~> 2.1.4"
   spec.add_development_dependency "rake", "~> 13.0.1"

--- a/sequra-style.gemspec
+++ b/sequra-style.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+  spec.files = Dir.chdir(File.expand_path("..", __FILE__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
   spec.bindir        = "exe"


### PR DESCRIPTION
This PR is part of the learning (hack) hour.

It adds/changes a few things:
- updates `rubocop` and other dependencies,
- adds a `.rubocop.yml` file (this was to test out the config, but I think it could stay),
- updates `README.md` (some info didn't apply to this gem),
- adds a `Gemfile.lock` file,
- cleans up `default.yml` to suppress the warnings,
- disables `RSpec/NestedGroups` cop (we are usually disabling it or not following it).

This will also possibly mean updating dependencies in all projects where's it's used -> that's the next step.