### PR TITLE
Disable Rails/ContentTag

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -26,6 +26,11 @@ Rails/AssertNot:
   Include:
     - "**/spec/**/*"
 
+# Don't enforce tag over content tag until this issue is properly handled:
+# https://github.com/rubocop-hq/rubocop-rails/issues/260
+Rails/ContentTag:
+  Enabled: false
+
 Rails/FilePath:
   EnforcedStyle: "arguments"
 


### PR DESCRIPTION
### Context

Rubocop enforces `#tag` instead of `#content_tag` even though they are not the same right now, with crucial differences.

Issue in Rubocop suggesting it shouldn’t enforce the change in all cases:

https://github.com/rubocop-hq/rubocop-rails/issues/260

PR that disables the cop in the Foreman Ansible repo:
* https://github.com/theforeman/foreman_ansible/pull/357
* [Specific diff](https://github.com/theforeman/foreman_ansible/pull/357/files#diff-4f894049af3375c2bd4e608f546f8d4a0eed95464efcdea850993200db9fef5cR39)

### Incident in Timon

We’ve updated the merchant `/edit` form with a few changes because we have moved some limits configuration from one place of the DB to another.

When creating a new method that renders a field, Rubocop told us to use `#tag` instead of `#content_tag` (because they are similar in the latest version of Rails)… and we did.

This broke the merchant /edit form, nesting fields inside fields inside fields.

This commit ended up fixing the problem: https://github.com/sequra/timon/commit/54b033e0b1a9e527e3ab0d207638b7010ce55349
