### PR TITLE
docs: remove mention to percy blog since it does not resolve anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # sequra-style
 
 SeQura code style guides and shared configuration.
-Inspired by Percy Blog [post](https://blog.percy.io/share-rubocop-rules-across-all-of-your-repos-f3281fbd71f8)
 
 ## Installation
 


### PR DESCRIPTION
### What is the goal?

Trigger a release.

### Is this a rectricting or expanding change?

None, just a doc update.

### How is it being implemented?

Update README file.

### Opportunistic refactorings

Remove mention to `blog.percy.io` in README file since the domain does not resolve.

### Caveats

None.

### How is it tested?

Automatic tests
