### PR TITLE
fix: Allow pushing gem to rubygems.pkg.github.com

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,15 +20,14 @@ jobs:
         with:
           ruby-version: 3.2
         if: ${{ steps.release.outputs.release_created }}
-      - name: Publish gem to Github repository packages
+      - name: Publish gem to Rubygems
         run: |
           mkdir -p $HOME/.gem
           touch $HOME/.gem/credentials
           chmod 0600 $HOME/.gem/credentials
-          printf -- "---\n:github: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+          printf -- "---\n:rubygems: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
           gem build *.gemspec
-          gem push --KEY github --host https://rubygems.pkg.github.com/${OWNER} *.gem
+          gem push --KEY rubygems --host https://rubygems.org *.gem
         env:
-          GEM_HOST_API_KEY: "Bearer ${{secrets.GITHUB_TOKEN}}"
-          OWNER: ${{ github.repository_owner }}
+          GEM_HOST_API_KEY: "${{ secrets.RUBYGEMS_PUBLISH_TOKEN }}"
         if: ${{ steps.release.outputs.release_created }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Joel Junström
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sequra-style.gemspec
+++ b/sequra-style.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)
-    spec.metadata["allowed_push_host"] = ""
+    spec.metadata["allowed_push_host"] = "https://rubygems.pkg.github.com"
 
     spec.metadata["homepage_uri"] = spec.homepage
     spec.metadata["source_code_uri"] = spec.homepage

--- a/sequra-style.gemspec
+++ b/sequra-style.gemspec
@@ -11,18 +11,6 @@ Gem::Specification.new do |spec|
   spec.summary       = "Sequra code style guides and shared config"
   spec.homepage      = "https://github.com/sequra/sequra-style"
 
-  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
-  # to allow pushing to a single host or delete this section to allow pushing to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata["allowed_push_host"] = "https://rubygems.pkg.github.com"
-
-    spec.metadata["homepage_uri"] = spec.homepage
-    spec.metadata["source_code_uri"] = spec.homepage
-  else
-    raise "RubyGems 2.0 or newer is required to protect against " \
-      "public gem pushes."
-  end
-
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files = Dir.chdir(File.expand_path("..", __FILE__)) do

--- a/sequra-style.gemspec
+++ b/sequra-style.gemspec
@@ -5,8 +5,8 @@ require "sequra/style/version"
 Gem::Specification.new do |spec|
   spec.name          = "sequra-style"
   spec.version       = Sequra::Style::VERSION
-  spec.authors       = ["Sequra"]
-  spec.email         = ["tech@sequra.es"]
+  spec.authors       = ["Sequra engineering"]
+  spec.email         = ["dev@sequra.es"]
 
   spec.summary       = "Sequra code style guides and shared config"
   spec.homepage      = "https://github.com/sequra/sequra-style"

--- a/sequra-style.gemspec
+++ b/sequra-style.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = "Sequra code style guides and shared config"
   spec.homepage      = "https://github.com/sequra/sequra-style"
+  spec.license       = "MIT"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/sequra-style.gemspec
+++ b/sequra-style.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   spec.name          = "sequra-style"
   spec.version       = Sequra::Style::VERSION
   spec.authors       = ["Sequra engineering"]
-  spec.email         = ["dev@sequra.es"]
+  spec.email         = ["rubygems@sequra.es"]
 
   spec.summary       = "Sequra code style guides and shared config"
   spec.homepage      = "https://github.com/sequra/sequra-style"


### PR DESCRIPTION
### What is the goal?

Publish gem in rubygems.org

### Is this a restricting or expanding change?

None.

### How is it being implemented?

- Remove `allowed_push_host` from gemspec
- Set author an email in gemspec to those in [norma43_parser](https://github.com/sequra/norma43_parser/blob/master/norma43_parser.gemspec)
- Adapt GH action release push step to use `rubygems.org` instead of `rubygems.pkg.github.com`
- Add MIT license

### Opportunistic refactorings

None.

### Caveats

None.

### How is it tested?

Manual tests.