### PR TITLE
feat: add Layout/AccessModifierIndentation

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -58,6 +58,10 @@ Style/NestedModifier:
 Style/SoleNestedConditional:
   Enabled: true
 
+# https://docs.rubocop.org/rubocop/cops_layout.html#layoutaccessmodifierindentation
+Layout/AccessModifierIndentation:
+  EnforcedStyle: outdent
+
 # Align `when` with `case`.
 Layout/CaseIndentation:
   Enabled: true

--- a/default.yml
+++ b/default.yml
@@ -61,6 +61,7 @@ Style/SoleNestedConditional:
 # https://docs.rubocop.org/rubocop/cops_layout.html#layoutaccessmodifierindentation
 Layout/AccessModifierIndentation:
   EnforcedStyle: outdent
+  Severity: info
 
 # Align `when` with `case`.
 Layout/CaseIndentation:


### PR DESCRIPTION
### What is the goal?
To standardise how `private` sections are indented in a class
While navigating Simba, I found a couple of classes with the `private` section indented (e.g. [ServiceItems::ServiceItemStates::HandlerJob](https://github.com/sequra/simba/blob/master/packs/service_items/app/jobs/service_items/service_item_states/handler_job.rb)) and found that Rubocop did not complain.
We've usually used the outdented version
```ruby
class Blop
  def initialize
  end

private

  def private_method
  end
end
```
This PR just adds the cop that looks for that outdentation.

### Is this a restricting or expanding change?
**RESTRICTING change**

### How is it tested?
Manual tests