### PR TITLE
fix: add note about severity level for restricting changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ Here are some friendly reminders before submitting your pull request:
 
 - There should be a goal describing the motivation for this change.
 - Consider if this change is restricting current style or expanding it.
-- Changes should be discussed with the team before being accepted
+- Changes should be discussed with the team before being accepted.
 - Restricting changes should have [severity level `info`](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Severity) to allow time for adoption before making them mandatory.
 
 YOU CAN REMOVE THE PARTS OF THE TEMPLATE THAT DO NOT APPLY TO YOUR PULL REQUEST

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,8 @@ Here are some friendly reminders before submitting your pull request:
 
 - There should be a goal describing the motivation for this change.
 - Consider if this change is restricting current style or expanding it.
-- Restricting changes should be discussed with the team before being accepted, and their [severity level should be set to `info`](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Severity) to allow time for adoption before making them mandatory.
+- Changes should be discussed with the team before being accepted
+- Restricting changes should have [severity level `info`](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Severity) to allow time for adoption before making them mandatory.
 
 YOU CAN REMOVE THE PARTS OF THE TEMPLATE THAT DO NOT APPLY TO YOUR PULL REQUEST
 
@@ -24,7 +25,9 @@ _Provide a description of the overall goal._
 
 _Restricting changes are those that limit the current style or add new rules, while expanding changes are those that remove rules or relax the current ones._
 
-_Rectricting changes should be discussed with the team before being accepted, and their [severity level set to `info`](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Severity) to allow time for adoption before making them mandatory._
+_Changes should be discussed with the team before being accepted._
+
+_Restricting changes should have [severity level `info`](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Severity) to allow time for adoption before making them mandatory._
 
 ### References
 * **Related pull-requests:** _list of related pull-requests (comma-separated): #1, #2_

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,7 @@ Here are some friendly reminders before submitting your pull request:
 
 - There should be a goal describing the motivation for this change.
 - Consider if this change is restricting current style or expanding it.
+- Restricting changes should be discussed with the team before being accepted, and their [severity level should be set to `info`](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Severity) to allow time for adoption before making them mandatory.
 
 YOU CAN REMOVE THE PARTS OF THE TEMPLATE THAT DO NOT APPLY TO YOUR PULL REQUEST
 
@@ -15,7 +16,7 @@ YOU CAN REMOVE THE PARTS OF THE TEMPLATE THAT DO NOT APPLY TO YOUR PULL REQUEST
 
 ### What is the goal?
 
-_Provide a description of the overall goal (you can usually use the one from the issue)_
+_Provide a description of the overall goal._
 
 ### Is this a restricting or expanding change?
 
@@ -23,8 +24,9 @@ _Provide a description of the overall goal (you can usually use the one from the
 
 _Restricting changes are those that limit the current style or add new rules, while expanding changes are those that remove rules or relax the current ones._
 
+_Rectricting changes should be discussed with the team before being accepted, and their [severity level set to `info`](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Severity) to allow time for adoption before making them mandatory._
+
 ### References
-* **Issue:** _jira issue goes here, if suggesting a new feature or change, please discuss it in an issue first_
 * **Related pull-requests:** _list of related pull-requests (comma-separated): #1, #2_
 * **Any other references:** _list of links to other references (comma-separated): link1, link2_
 
@@ -39,9 +41,3 @@ _Have you improved the code/app in anyway? Explain what you did._
 ### Caveats
 
 _If you find any, please describe all the special conditions._
-
-### How is it tested?
-
-_Automatic tests? Manual tests?_
-
-_If it cannot be tested explain why._


### PR DESCRIPTION
### What is the goal?

Restricting changes should start as informational to allow time for teams to adopt the change in their code bases without suddenly breaking their pipelines. Add a note about this in the PR template to clarify the expected flow.

### Is this a restricting or expanding change?

NA.

### References

None.

### How is it being implemented?

- Update PR template

### Opportunistic refactorings

None.

### Caveats

None.
