### PR TITLE
fix: Fix release-please version path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
           release-type: ruby
           package-name: sequra-style
           bump-minor-pre-major: true
-          version-file: 'lib/sequra/sequra-style/version.rb'
+          version-file: 'lib/sequra/style/version.rb'
       - uses: actions/checkout@v2
         if: ${{ steps.release.outputs.release_created }}
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
### What is the goal?

Fix release-please version path to generate proper version in rubygems

### Is this a restricting or expanding change?

None.

### How is it being implemented?

- Fix `version.rb` path in release-please configuration

### Caveats

None.
