### PR TITLE
feat: Add RSpec/ContextMethod rule only as warning

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -282,6 +282,9 @@ Performance/RegexpMatch:
 RSpec/ContextWording:
   Enabled: false
 
+RSpec/ContextMethod:
+  Severity: info
+
 RSpec/ExampleLength:
   Max: 16
 


### PR DESCRIPTION
### What is the goal?

Improve clarity, readability, consistency, and avoid ambiguity in our RSpec tests by adding the [`RSpec/ContextMethod` ](https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspeccontextmethod) rule.

🤓 Using describe and context methods explicitly communicates the code's intention more clearly, making it easier for other developers to understand the structure of the tests.

![Screenshot 2024-05-10 at 17 06 36](https://github.com/sequra/sequra-style/assets/30449248/ea0fef9e-27ed-4f3e-8673-71fc3dec2bed)


Currently, we have **186 offenses** to this rule.

### Is this a restricting or expanding change?

**RESTRICTING change**

### References
* **Related pull-requests:** https://github.com/sequra/simba/pull/8245

### How is it being implemented?

I just added the rule to `default.yml` 

### Opportunistic refactorings

No

### Caveats

I'll fix the **186 offenses** in PRs like this one https://github.com/sequra/simba/pull/8245 after this rule is approved 🤞🏽 💕 