### PR TITLE
fix: Exclude rswag tests from Rails/HttpPositionalArguments

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -34,6 +34,11 @@ Rails/ContentTag:
 Rails/FilePath:
   EnforcedStyle: "arguments"
 
+# Exclude rswag specs from this cop, as it missinterprets test tags
+Rails/HttpPositionalArguments:
+  Exclude:
+    - '**/spec/api/**/*'
+
 # Prefer assert_not_x over refute_x
 Rails/RefuteMethods:
   Include:


### PR DESCRIPTION
### What is the goal?

Exclude rswag tests from `Rails/HttpPositionalArguments` scrutiny, as rubocop misinterprets test tags.

### Is this a restricting or expanding change?

**EXPANDING change**

### How is it being implemented?

Add path exclusion to `Rails/HttpPositionalArguments`.

### Opportunistic refactorings

None.

### Caveats

None.
