### PR TITLE
fix: bump rubocop obsession

### DIFF
--- a/sequra-style.gemspec
+++ b/sequra-style.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rubocop-performance", "~> 1"
   spec.add_dependency "rubocop-rails", "~> 2"
   spec.add_dependency "rubocop-rspec", "~> 2"
-  spec.add_dependency "rubocop-obsession", "~> 0.1.11"
+  spec.add_dependency "rubocop-obsession", "~> 0.2"
 
   spec.add_development_dependency "bundler", "~> 2.1.4"
   spec.add_development_dependency "rake", "~> 13.0.1"


### PR DESCRIPTION
### What is the goal?

Bump rubocop obsession

### Is this a restricting or expanding change?

N/A

### References
* https://github.com/jeromedalbert/rubocop-obsession/blob/main/CHANGELOG.md

### How is it being implemented?

Bump version in gemspec

### Opportunistic refactorings

None.

### Caveats

None.
