### PR TITLE
fix: require to plugins

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-performance
   - rubocop-rails
   - rubocop-rspec

--- a/sequra-style.gemspec
+++ b/sequra-style.gemspec
@@ -21,10 +21,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 1"
-  spec.add_dependency "rubocop-performance", "~> 1"
-  spec.add_dependency "rubocop-rails", "~> 2"
-  spec.add_dependency "rubocop-rspec", "~> 2"
+  spec.add_dependency "rubocop", "~> 1.75"
+  spec.add_dependency "rubocop-performance", "~> 1.25"
+  spec.add_dependency "rubocop-rails", "~> 2.31"
+  spec.add_dependency "rubocop-rspec", "~> 3.5"
   spec.add_dependency "rubocop-obsession", "~> 0.2"
 
   spec.add_development_dependency "bundler", "~> 2.1.4"


### PR DESCRIPTION
### What is the goal?

Since rubocop 1.72, [extensions should now be loaded as plugins instead of being required](https://docs.rubocop.org/rubocop/extensions.html#loading-extensions). Use `plugins` instead of `require` in rubocop configuration.

### Is this a restricting or expanding change?

N/A

### References
* **Any other references:** https://docs.rubocop.org/rubocop/extensions.html#loading-extensions

### How is it being implemented?

- Upgrade extensions.
- Replace 'require' with 'plugins' in rubocop configuration.

### Opportunistic refactorings

None.

### Caveats

None.
