### PR TITLE
feat: Remove Obsession/MethodOrder cop

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     sequra-style (1.3.3)
       rubocop (~> 1)
-      rubocop-obsession (~> 0.1.11)
       rubocop-performance (~> 1)
       rubocop-rails (~> 2)
       rubocop-rspec (~> 2)
@@ -60,9 +59,6 @@ GEM
       unicode-display_width (>= 2.4.0, < 4.0)
     rubocop-ast (1.38.1)
       parser (>= 3.3.1.0)
-    rubocop-obsession (0.1.15)
-      activesupport
-      rubocop (~> 1.41)
     rubocop-performance (1.15.1)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)

--- a/default.yml
+++ b/default.yml
@@ -2,7 +2,6 @@ plugins:
   - rubocop-performance
   - rubocop-rails
   - rubocop-rspec
-  - rubocop-obsession
 
 AllCops:
   # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop
@@ -264,11 +263,6 @@ Style/TrivialAccessors:
 # Use guard clauses when possible
 Style/GuardClause:
   Enabled: true
-
-Obsession/MethodOrder:
-  Enabled: true
-  EnforcedStyle: step_down
-  Severity: info
 
 Performance/FlatMap:
   Enabled: true

--- a/sequra-style.gemspec
+++ b/sequra-style.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rubocop-performance", "~> 1.25"
   spec.add_dependency "rubocop-rails", "~> 2.31"
   spec.add_dependency "rubocop-rspec", "~> 3.5"
-  spec.add_dependency "rubocop-obsession", "~> 0.2"
 
   spec.add_development_dependency "bundler", "~> 2.1.4"
   spec.add_development_dependency "rake", "~> 13.0.1"


### PR DESCRIPTION

### What is the goal?

Remove the `Obsession/MethodOrder` cop.

Ideally we would all take the time to split refactors out in separate PRs. In reality, most of the time these refactors are always added in with the rest of the changes. This makes it very hard to review even small changes when methods are moved up and down files -- especially when the body of the moved methods is changed too.

### Is this a restricting or expanding change?

**EXPANDING change**

### References
* **Related pull-requests:** https://github.com/sequra/sequra-style/pull/32
