### PR TITLE
feat: disable example length rule

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -1,4 +1,4 @@
-plugins:
+require:
   - rubocop-performance
   - rubocop-rails
   - rubocop-rspec

--- a/default.yml
+++ b/default.yml
@@ -1,9 +1,7 @@
-# WARNING: DO NOT LIST PLUGINS HERE!
-# `inherit_gem` doesn't support plugins yet. Plugins must be listed in the .rubocop.yml file of each project for now
-# require:
-#   - rubocop-performance
-#   - rubocop-rails
-#   - rubocop-rspec
+plugins:
+  - rubocop-performance
+  - rubocop-rails
+  - rubocop-rspec
 
 AllCops:
   # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop
@@ -299,7 +297,7 @@ RSpec/ContextMethod:
   Severity: info
 
 RSpec/ExampleLength:
-  Enabled: false
+  Max: 999
 
 RSpec/MultipleExpectations:
   Enabled: false

--- a/default.yml
+++ b/default.yml
@@ -297,7 +297,7 @@ RSpec/ContextMethod:
   Severity: info
 
 RSpec/ExampleLength:
-  Max: 16
+  Enabled: false
 
 RSpec/MultipleExpectations:
   Enabled: false

--- a/default.yml
+++ b/default.yml
@@ -297,6 +297,9 @@ RSpec/ContextMethod:
   Severity: info
 
 RSpec/ExampleLength:
+  # WORKAROUND: `Enabled: false` is ignored due to a loading order bug with
+  # `inherit_gem` and `rubocop-rspec` plugins. We set a high Max to silence it
+  # while keeping the plugin definition self-contained in this gem.
   Max: 999
 
 RSpec/MultipleExpectations:

--- a/default.yml
+++ b/default.yml
@@ -1,7 +1,9 @@
-require:
-  - rubocop-performance
-  - rubocop-rails
-  - rubocop-rspec
+# WARNING: DO NOT LIST PLUGINS HERE!
+# `inherit_gem` doesn't support plugins yet. Plugins must be listed in the .rubocop.yml file of each project for now
+# require:
+#   - rubocop-performance
+#   - rubocop-rails
+#   - rubocop-rspec
 
 AllCops:
   # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop


### PR DESCRIPTION
### What is the goal?

Disable `RSpec/ExampleLength` in the shared config. Due to a known loading order bug between `inherit_gem` and `rubocop-rspec` 3.0+ plugins, the standard `Enabled: false` setting is being ignored and overwritten by plugin defaults.

### Is this a restricting or expanding change?

**EXPANDING change**

### References
[Different extension behavior](https://github.com/testdouble/standard/issues/507), [RuboCop RSpec Changelog / Upgrade Guide](https://docs.rubocop.org/rubocop-rspec/upgrade_to_version_3.html)

### How is it being implemented?

By forcing `Max: 999` in `default.yml`. Unlike the `Enabled` status, configuration parameters like `Max` persist through the plugin loading merge. This silences the cop for all practical purposes.

### Caveats

* **Workaround:** The cop remains technically "Enabled" but will not flag offenses unless an example exceeds 999 lines.
* **Trade-off:** This was chosen over alternatives that would imply replicating settings in the multiple .rubocop.yml files of projects using this gem.