### PR TITLE
feat: Add shared_context and shared_examples exceptions to MethodCallWithArgsParentheses

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -672,6 +672,8 @@ Style/MethodCallWithArgsParentheses:
     - redirect_to
     - render
     - send_data
+    - shared_context
+    - shared_examples
     - snapshot!
     - step_to
     - to


### PR DESCRIPTION
### What is the goal?

Add `shared_context` and `shared_examples` to the list of ignored methods for the `Style/MethodCallWithArgsParentheses` cop. These RSpec helpers are commonly called without parentheses, so enforcing them causes unnecessary friction.

### Is this a restricting or expanding change?

**EXPANDING change**

Relaxes the current rule by adding two new method exceptions, reducing the number of offenses flagged.

### References

* **Related pull-requests:** #67

### How is it being implemented?

Two entries — `shared_context` and `shared_examples` — are appended to the `IgnoredMethods` list of `Style/MethodCallWithArgsParentheses` in `default.yml`.