### PR TITLE
feat: [COR-1992] Add Sequra/NoSidekiqPerformStubs cop

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -832,3 +832,16 @@ Sequra/AsyncJobPattern:
     - "packs/*/app/workers/**/*.rb"
   Exclude:
     - "**/application_job.rb"
+
+# Forbid stubbing/spying on Sidekiq enqueue methods in specs. Stubs bypass
+# `Sidekiq.strict_args!` validation, which has caused silent production
+# failures (COR-1923). Use `have_enqueued_sidekiq_job` or
+# `change(Job.jobs, :size)` instead. `.and_call_original` is exempt.
+# Ships disabled so consumer repos opt in on their own timeline (paired with
+# `.rubocop_todo.yml` to grandfather existing offenses).
+Sequra/NoSidekiqPerformStubs:
+  Enabled: false
+  Include:
+    - "**/*_spec.rb"
+    - "**/spec/support/**/*.rb"
+    - "**/spec/shared_examples/**/*.rb"

--- a/lib/rubocop/cop/sequra/no_sidekiq_perform_stubs.rb
+++ b/lib/rubocop/cop/sequra/no_sidekiq_perform_stubs.rb
@@ -1,0 +1,77 @@
+module RuboCop
+  module Cop
+    module Sequra
+      # Detects RSpec stubs and spy assertions on Sidekiq enqueue methods
+      # (`perform_async`, `perform_at`, `perform_in`).
+      #
+      # Stubbing these methods bypasses `Sidekiq.strict_args!` validation,
+      # which lets symbol-keyed hashes (and other non-JSON-native types)
+      # slip through unchecked. The same code would raise `ArgumentError`
+      # in production at enqueue time, and the bug only surfaces when the
+      # job actually runs — by which point retries, timing windows, and
+      # rescue-swallowers can mask the failure. This pattern caused a
+      # silent push-notification drop in COR-1923.
+      #
+      # Use `have_enqueued_sidekiq_job` (or `change(SomeJob.jobs, :size)`)
+      # instead. Both go through Sidekiq's client middleware chain, so
+      # `strict_args!` validates the arguments as it would in production.
+      #
+      # `.and_call_original` is exempt: the stub spies on the call but
+      # then runs the real `perform_*`, which still exercises the
+      # serialization contract.
+      #
+      # @example
+      #   # bad - stub bypasses strict_args! validation
+      #   allow(SomeJob).to receive(:perform_async)
+      #
+      #   # bad - even with arg matchers, the real enqueue is suppressed
+      #   expect(SomeJob).to receive(:perform_at).with(time, data)
+      #
+      #   # bad - negative assertion still bypasses the contract
+      #   expect(SomeJob).not_to receive(:perform_async)
+      #
+      #   # bad - spy verification on a stubbed enqueue
+      #   expect(SomeJob).to have_received(:perform_async).with(id)
+      #
+      #   # good - exercises strict_args! through Sidekiq's middleware
+      #   expect(SomeJob).to have_enqueued_sidekiq_job(id, name: "value")
+      #
+      #   # good - state-based assertion, also exercises the middleware
+      #   expect { subject }.to change(SomeJob.jobs, :size).by(1)
+      #
+      #   # good - escape hatch: spy AND run the real method
+      #   expect(SomeJob).to receive(:perform_async).and_call_original
+      #
+      class NoSidekiqPerformStubs < Base
+        MSG = "Avoid stubbing Sidekiq enqueue methods (`perform_async`/`perform_at`/`perform_in`). " \
+              "Stubs bypass `Sidekiq.strict_args!` validation and can hide symbol-keyed hash bugs " \
+              "(see COR-1923). Use `have_enqueued_sidekiq_job` or `change(Job.jobs, :size)` instead. " \
+              "Use `.and_call_original` only as an escape hatch.".freeze
+
+        def_node_matcher :perform_method_stub?, <<~PATTERN
+          (send nil? {:receive :have_received} (sym {:perform_async :perform_at :perform_in}))
+        PATTERN
+
+        def on_send(node)
+          return unless perform_method_stub?(node)
+          return if chained_with_call_original?(node)
+
+          add_offense(node)
+        end
+
+        private
+
+        def chained_with_call_original?(node)
+          current = node
+          loop do
+            parent = current.parent
+            return false unless parent&.send_type? && parent.receiver == current
+            return true if parent.method_name == :and_call_original
+
+            current = parent
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/sequra_style.rb
+++ b/lib/sequra_style.rb
@@ -1,2 +1,3 @@
 require "rubocop"
 require_relative "rubocop/cop/sequra/async_job_pattern"
+require_relative "rubocop/cop/sequra/no_sidekiq_perform_stubs"

--- a/spec/rubocop/cop/sequra/no_sidekiq_perform_stubs_spec.rb
+++ b/spec/rubocop/cop/sequra/no_sidekiq_perform_stubs_spec.rb
@@ -1,0 +1,231 @@
+require "spec_helper"
+
+RSpec.describe RuboCop::Cop::Sequra::NoSidekiqPerformStubs, :config do
+  let(:config) do
+    RuboCop::Config.new(
+      "Sequra/NoSidekiqPerformStubs" => {
+        "Enabled" => true,
+      }
+    )
+  end
+
+  context "with `allow(...).to receive(...)` stubs" do
+    it "flags bare perform_async" do
+      expect_offense(<<~RUBY)
+        allow(SomeJob).to receive(:perform_async)
+                          ^^^^^^^^^^^^^^^^^^^^^^^ #{described_class::MSG}
+      RUBY
+    end
+
+    it "flags perform_at" do
+      expect_offense(<<~RUBY)
+        allow(SomeJob).to receive(:perform_at)
+                          ^^^^^^^^^^^^^^^^^^^^ #{described_class::MSG}
+      RUBY
+    end
+
+    it "flags perform_in" do
+      expect_offense(<<~RUBY)
+        allow(SomeJob).to receive(:perform_in)
+                          ^^^^^^^^^^^^^^^^^^^^ #{described_class::MSG}
+      RUBY
+    end
+
+    it "flags with chained `.and_return`" do
+      expect_offense(<<~RUBY)
+        allow(SomeJob).to receive(:perform_async).and_return("jid")
+                          ^^^^^^^^^^^^^^^^^^^^^^^ #{described_class::MSG}
+      RUBY
+    end
+
+    it "flags with chained `.and_raise`" do
+      expect_offense(<<~RUBY)
+        allow(SomeJob).to receive(:perform_async).and_raise(StandardError)
+                          ^^^^^^^^^^^^^^^^^^^^^^^ #{described_class::MSG}
+      RUBY
+    end
+
+    it "flags with chained `.with(args)`" do
+      expect_offense(<<~RUBY)
+        allow(SomeJob).to receive(:perform_async).with(123)
+                          ^^^^^^^^^^^^^^^^^^^^^^^ #{described_class::MSG}
+      RUBY
+    end
+
+    it "flags with chained `.with(args).and_return`" do
+      expect_offense(<<~RUBY)
+        allow(SomeJob).to receive(:perform_async).with(123).and_return("jid")
+                          ^^^^^^^^^^^^^^^^^^^^^^^ #{described_class::MSG}
+      RUBY
+    end
+
+    it "flags namespaced job classes" do
+      expect_offense(<<~RUBY)
+        allow(MyPack::SomeJob).to receive(:perform_async)
+                                  ^^^^^^^^^^^^^^^^^^^^^^^ #{described_class::MSG}
+      RUBY
+    end
+  end
+
+  context "with `expect(...).to receive(...)` stubs" do
+    it "flags positive expectation" do
+      expect_offense(<<~RUBY)
+        expect(SomeJob).to receive(:perform_async)
+                           ^^^^^^^^^^^^^^^^^^^^^^^ #{described_class::MSG}
+      RUBY
+    end
+
+    it "flags negative expectation with `not_to`" do
+      expect_offense(<<~RUBY)
+        expect(SomeJob).not_to receive(:perform_async)
+                               ^^^^^^^^^^^^^^^^^^^^^^^ #{described_class::MSG}
+      RUBY
+    end
+
+    it "flags negative expectation with `to_not`" do
+      expect_offense(<<~RUBY)
+        expect(SomeJob).to_not receive(:perform_at)
+                               ^^^^^^^^^^^^^^^^^^^^ #{described_class::MSG}
+      RUBY
+    end
+
+    it "flags expectation with count constraint" do
+      expect_offense(<<~RUBY)
+        expect(SomeJob).to receive(:perform_async).exactly(2).times
+                           ^^^^^^^^^^^^^^^^^^^^^^^ #{described_class::MSG}
+      RUBY
+    end
+  end
+
+  context "with `have_received` spy assertions" do
+    it "flags positive spy on perform_async" do
+      expect_offense(<<~RUBY)
+        expect(SomeJob).to have_received(:perform_async)
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{described_class::MSG}
+      RUBY
+    end
+
+    it "flags negative spy with `not_to`" do
+      expect_offense(<<~RUBY)
+        expect(SomeJob).not_to have_received(:perform_async)
+                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{described_class::MSG}
+      RUBY
+    end
+
+    it "flags spy with `.with(args)`" do
+      expect_offense(<<~RUBY)
+        expect(SomeJob).to have_received(:perform_at).with(time, data)
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^ #{described_class::MSG}
+      RUBY
+    end
+
+    it "flags spy with `.twice` count constraint" do
+      expect_offense(<<~RUBY)
+        expect(SomeJob).to have_received(:perform_async).twice
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{described_class::MSG}
+      RUBY
+    end
+  end
+
+  context "with `allow_any_instance_of` / `expect_any_instance_of`" do
+    it "flags allow_any_instance_of with perform_async" do
+      expect_offense(<<~RUBY)
+        allow_any_instance_of(SomeJob).to receive(:perform_async)
+                                          ^^^^^^^^^^^^^^^^^^^^^^^ #{described_class::MSG}
+      RUBY
+    end
+
+    it "flags expect_any_instance_of with perform_in" do
+      expect_offense(<<~RUBY)
+        expect_any_instance_of(SomeJob).to receive(:perform_in)
+                                           ^^^^^^^^^^^^^^^^^^^^ #{described_class::MSG}
+      RUBY
+    end
+  end
+
+  context "with `.and_call_original` escape hatch" do
+    it "does not flag `receive(:perform_async).and_call_original`" do
+      expect_no_offenses(<<~RUBY)
+        expect(SomeJob).to receive(:perform_async).and_call_original
+      RUBY
+    end
+
+    it "does not flag `receive(:perform_at).and_call_original`" do
+      expect_no_offenses(<<~RUBY)
+        allow(SomeJob).to receive(:perform_at).and_call_original
+      RUBY
+    end
+
+    it "does not flag `receive(:perform_async).with(args).and_call_original`" do
+      expect_no_offenses(<<~RUBY)
+        expect(SomeJob).to receive(:perform_async).with(123).and_call_original
+      RUBY
+    end
+
+    it "does not flag long chains ending in `.and_call_original`" do
+      expect_no_offenses(<<~RUBY)
+        expect(SomeJob).to receive(:perform_async).with(123).once.ordered.and_call_original
+      RUBY
+    end
+  end
+
+  context "with correct enqueue assertions" do
+    it "does not flag `have_enqueued_sidekiq_job`" do
+      expect_no_offenses(<<~RUBY)
+        expect(SomeJob).to have_enqueued_sidekiq_job(123, name: "value")
+      RUBY
+    end
+
+    it "does not flag `change(Job.jobs, :size)`" do
+      expect_no_offenses(<<~RUBY)
+        expect { subject }.to change(SomeJob.jobs, :size).by(1)
+      RUBY
+    end
+
+    it "does not flag direct queue inspection" do
+      expect_no_offenses(<<~RUBY)
+        expect(SomeJob.jobs.last["args"]).to eq([123, "name"])
+      RUBY
+    end
+
+    it "does not flag `Sidekiq::Worker.drain_all`" do
+      expect_no_offenses(<<~RUBY)
+        Sidekiq::Worker.drain_all
+      RUBY
+    end
+  end
+
+  context "with unrelated stubs" do
+    it "does not flag stubs on other methods" do
+      expect_no_offenses(<<~RUBY)
+        allow(SomeService).to receive(:call).and_return(true)
+      RUBY
+    end
+
+    it "does not flag stubs on methods named like perform but not the enqueue API" do
+      expect_no_offenses(<<~RUBY)
+        allow(SomeJob).to receive(:perform).and_return(nil)
+      RUBY
+    end
+
+    it "does not flag spies on other methods" do
+      expect_no_offenses(<<~RUBY)
+        expect(SomeService).to have_received(:call).with(123)
+      RUBY
+    end
+  end
+
+  context "when the symbol matches as a partial / different argument" do
+    it "does not flag `receive` with a different symbol that contains 'perform'" do
+      expect_no_offenses(<<~RUBY)
+        allow(SomeJob).to receive(:perform).with(123)
+      RUBY
+    end
+
+    it "does not flag string method names (RSpec accepts strings but rare)" do
+      expect_no_offenses(<<~RUBY)
+        allow(SomeJob).to receive("perform_async")
+      RUBY
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require "rubocop"
 require "rubocop/rspec/support"
 
 require_relative "../lib/rubocop/cop/sequra/async_job_pattern"
+require_relative "../lib/rubocop/cop/sequra/no_sidekiq_perform_stubs"
 
 RSpec.configure do |config|
   config.include(RuboCop::RSpec::ExpectOffense)


### PR DESCRIPTION
## Summary

Adds `Sequra/NoSidekiqPerformStubs` — a RuboCop cop that forbids stubbing or spying on Sidekiq enqueue methods (`perform_async`/`perform_at`/`perform_in`) in specs.

**Why:** stubs bypass `Sidekiq.strict_args!`, so symbol-keyed hashes (and other non-JSON-native args) pass specs but raise `ArgumentError` in production. When the production raise is swallowed by a top-level `rescue StandardError` in the job, the failure is silent. COR-1923 was the latest recurrence — push notifications dropped silently for ~12 h/day after a feature flag rolled on, because per-feature ops forwarded Symbol-keyed `notification_data` to `Job.perform_at` and specs (which stubbed the enqueue) never exercised the contract.

## What the cop does

- Flags `receive(:perform_async|:perform_at|:perform_in)` and `have_received(:perform_async|:perform_at|:perform_in)`.
- Covers all common stub shapes: `allow`, `expect`, `not_to`/`to_not`, `allow_any_instance_of`/`expect_any_instance_of`, chained `.with`/`.and_return`/`.and_raise`/`.exactly(n).times`/etc.
- **Exempts** `.and_call_original` chains — the spy still invokes the real enqueue, so `strict_args!` validates the args.
- **Does not flag** the recommended replacements: `have_enqueued_sidekiq_job`, `change(SomeJob.jobs, :size)`, or direct queue inspection (`SomeJob.jobs.last["args"]`).
- Detect-only (no autocorrect) — the 5 stub buckets are not uniformly safe to rewrite mechanically (`.and_return`/`.and_raise` need human judgment per case).

## Rollout

Cop ships `Enabled: false` in `default.yml`. Consumer repos opt in by setting `Enabled: true` in their own `.rubocop.yml` on their own timeline. This avoids forcing a wave of new offenses on every repo when they bump `sequra-style`.

### Simba follow-up PR

Simba has ~1,560 existing offenses across ~250 spec files. The follow-up PR will:

1. Flip `Sequra/NoSidekiqPerformStubs: Enabled: true` in Simba's `.rubocop.yml`.
2. Add `match_when_negated` to Simba's custom `have_enqueued_sidekiq_job` matcher in `spec/support/sidekiq.rb` so the 141 negative assertions get readable failure messages.
3. Run `rubocop --auto-gen-config` to generate `.rubocop_todo.yml` grandfathering the existing offenses.
4. Drain the todo opportunistically — fix violations in spec files touched for unrelated work, plus targeted sweeps for high-risk packs (`push_notifications`, `transaction_monitoring`).

No big-bang migration. The cop's value is the forward-looking gate.

## Test plan

- [x] 31 RSpec examples in `spec/rubocop/cop/sequra/no_sidekiq_perform_stubs_spec.rb` covering positive/negative stubs, spy assertions, count constraints, `any_instance_of`, namespaced jobs, short and long `.and_call_original` chains, correct patterns (`have_enqueued_sidekiq_job`, `change(Job.jobs)`), unrelated stubs, false-positive guards (`receive(:perform)`, string method names).
- [x] Full suite passes (49 examples, 0 failures).
- [x] `rubocop` clean on new files.
- [x] Smoke test against a synthetic spec with 6 lines (3 violations, 3 correct patterns) → 3/3 flagged, 3/3 allowed.

## Related

- **COR-1923** — the latest recurrence the cop is designed to prevent (`#19088` `47a57b9`).
- `#19077` — the `and_call_original` regression-test pattern the cop's escape hatch is modeled on.