### PR TITLE
feat: Expand Metrics/ParameterLists to not count keyword arguments

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -385,6 +385,7 @@ Metrics/MethodLength:
 Metrics/ParameterLists:
   Max: 4
   Enabled: true
+  CountKeywordArgs: false
 
 # Avoid get_/set_ prefixes for accessor methods
 # https://rubystyle.guide/#accessor_mutator_method_names


### PR DESCRIPTION
### What is the goal?

Finders often need many keyword arguments to express different filtering combinations. The current `Metrics/ParameterLists` configuration counts keyword args toward the limit (Max: 4), which forces workarounds that obscure the finder's public API.

The typical workaround is collapsing filters into a single `filters:` hash — but that makes it impossible to know what the finder accepts without reading the implementation. Other alternatives (chained methods, multiple finders) either require a larger design discussion or add significant boilerplate.

Setting `CountKeywordArgs: false` relaxes the cop for keyword arguments only. Positional parameter guards remain unchanged.

### Is this a restricting or expanding change?

**EXPANDING change**

Removes keyword arguments from the `Metrics/ParameterLists` count, allowing finders (and other classes) to accept more named parameters without triggering the cop.

### References

* **Any other references:** Discussion context: a finder needed additional filter parameters and hit the Max: 4 limit. The team explored options — `CountKeywordArgs: false`, chained methods, a catch-all `filters:` hash, or splitting into multiple finders — and agreed that hiding keyword args behind a hash trades a false sense of compliance for real loss of discoverability.

### How is it being implemented?

Single-line addition to the `Metrics/ParameterLists` cop block in `default.yml`:

```yaml
Metrics/ParameterLists:
  Max: 4
  Enabled: true
  CountKeywordArgs: false
```

### Caveats

This affects all classes, not only finders. For operations and other classes where a large number of keyword arguments is itself a design smell, teams should still consider splitting responsibilities rather than relying on this relaxation.