### PR TITLE
feat: [COR-1993] Enable Style/RedundantConstantBase cop

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -736,6 +736,11 @@ Style/PreferredHashMethods:
 Style/RaiseArgs:
   Enabled: true
 
+# Don't prefix top-level constants with `::` when bare resolution is unambiguous
+# https://docs.rubocop.org/rubocop/cops_style.html#styleredundantconstantbase
+Style/RedundantConstantBase:
+  Enabled: true
+
 # Avoid explicit return where not required
 # https://rubystyle.guide/#no-explicit-return
 Style/RedundantReturn:


### PR DESCRIPTION
### What is the goal?

Stop the inconsistent mix of `::Foo` and bare `Foo` references for top-level constants across our Rails codebases. Code-review feedback on a recent Timon PR flagged the inconsistency in a single file. The cop is stock RuboCop, safe-autocorrect, and leaves load-bearing `::` alone (stdlib clashes, in-pack disambiguation).

### Is this a restricting or expanding change?

**RESTRICTING change**

Cleanup in consumer repos is a one-shot mechanical sweep via `rubocop -A`, so the cop is enabled at default severity rather than `info`.

### References

* **Related pull-requests:** Follow-up bump + autofix PR in Timon (per [COR-1993](https://sequra.atlassian.net/browse/COR-1993))
* **Any other references:** [Style/RedundantConstantBase docs](https://docs.rubocop.org/rubocop/cops_style.html#styleredundantconstantbase)

### How is it being implemented?

- Add `Style/RedundantConstantBase: Enabled: true` to `default.yml`.
- No offenses introduced in this repo's own code.

### Caveats

- Consumers must bump the gem and run `bundle exec rubocop -A` in a single mechanical commit to clear pre-existing `::` prefixes.


[COR-1993]: https://sequra.atlassian.net/browse/COR-1993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ