### PR TITLE
chore(deps): fix all open Dependabot security alerts

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (8.1.2)
+    activesupport (8.1.3)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
@@ -32,7 +32,7 @@ GEM
     drb (2.2.3)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    json (2.18.1)
+    json (2.19.8)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -44,7 +44,7 @@ GEM
       racc
     prism (1.9.0)
     racc (1.8.1)
-    rack (3.2.4)
+    rack (3.2.6)
     rainbow (3.1.1)
     rake (13.0.6)
     regexp_parser (2.11.3)
@@ -101,10 +101,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 2.1.4)
+  bundler (>= 2.2.33, < 3)
   rake (~> 13.0.1)
   rspec (~> 3.13)
   sequra-style!
 
 BUNDLED WITH
-   2.1.4
+   2.5.22

--- a/sequra-style.gemspec
+++ b/sequra-style.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rubocop-rails", "~> 2.31"
   spec.add_dependency "rubocop-rspec", "~> 3.5"
 
-  spec.add_development_dependency "bundler", "~> 2.1.4"
+  spec.add_development_dependency "bundler", ">= 2.2.33", "< 3"
   spec.add_development_dependency "rake", "~> 13.0.1"
   spec.add_development_dependency "rspec", "~> 3.13"
 end


### PR DESCRIPTION
### What is the goal?

Resolve all 21 open Dependabot security alerts on this repo (7 high, 14 medium).

### References
* **Issue:** [Dependabot alerts](https://github.com/sequra/sequra-style/security/dependabot)
* **Related pull-requests:** sequra/sequra-ruby-observability#162, sequra/sequra-commons#187 (same treatment)

### How is it being implemented?

Conservative `bundle update` of only the vulnerable gems, plus one gemspec change:

| Gem | From | To | Worst severity |
|-----|------|----|----------------|
| rack | 3.2.4 | 3.2.6 | high (multipart DoS, Rack::Static file exposure) |
| activesupport | 8.1.2 | 8.1.3 | medium |
| json | 2.18.1 | 2.19.8 | high |
| bundler (gemspec dev dep) | ~> 2.1.4 | >= 2.2.33, < 3 | high |

The `bundler` alerts were pinned by the gemspec's `~> 2.1.4` development dependency, so the constraint is relaxed to `>= 2.2.33, < 3` and the lockfile's `BUNDLED WITH` moves from the vulnerable 2.1.4 to 2.5.22.

All changes are dev/test-time only — the gem's runtime dependencies (rubocop and friends) are untouched, so no consumer-facing change (hence `chore`).

### Caveats

CI installs with bundler from `ruby/setup-ruby` on Ruby 3.2 — bundler 2.2.33+ is the default there, so the relaxed constraint and new `BUNDLED WITH` are compatible.

### How is it tested?

Full `bundle exec rspec` run: **49 examples, 0 failures**. RuboCop clean on the changed gemspec.