### PR TITLE
feat(rubocop): enable Style/OpenStructUse

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -716,6 +716,12 @@ Style/NegatedIf:
 Style/NestedModifier:
   Enabled: true
 
+# Ban OpenStruct usage (allocation-heavy: a singleton class + accessor methods
+# per instance). Prefer Data.define, Struct, a plain class, or test doubles.
+# Grandfather existing usages in your project's .rubocop_todo.yml.
+Style/OpenStructUse:
+  Enabled: true
+
 # Define optional arguments at end of parameter list
 # https://rubystyle.guide/#optional-arguments
 Style/OptionalArguments:


### PR DESCRIPTION
### What is the goal?

Stop new `OpenStruct` usage from entering projects that inherit this config. `OpenStruct` is allocation-heavy (each instance builds its own singleton class and accessor methods, ~200+ objects per instance) and is officially discouraged. Enabling it as a shared rule prevents regressions across every consumer.

### Is this a restricting or expanding change?

**RESTRICTING change**

Enabled at the cop's default severity (`convention`), so new `OpenStruct` usage fails CI. Any project that still has existing usages grandfathers them in its own `.rubocop_todo.yml` and removes them over time.

### How is it being implemented?

- Enable RuboCop's built-in `Style/OpenStructUse` in `default.yml` at default severity.
- No central grandfather list: existing usages live in each consumer's own `.rubocop_todo.yml`, so the rule stays precise per project.