### PR TITLE
feat(rubocop): add PrometheusMetricLabels cop

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -857,3 +857,14 @@ Sequra/NoSidekiqPerformStubs:
     - "**/*_spec.rb"
     - "**/spec/support/**/*.rb"
     - "**/spec/shared_examples/**/*.rb"
+
+# Catch malformed labels on prometheus_exporter metric calls. `increment`,
+# `decrement` and `observe` take labels as a positional hash, so a `labels:`
+# keyword silently produces a series labelled `labels="{...}"` that no
+# by-label query can match. Also catches the value/labels argument order,
+# which is reversed between `observe` and `increment`. Autocorrectable.
+# `warning` severity: these are silently broken metrics, not style, so they
+# fail the build rather than waiting for adoption.
+Sequra/PrometheusMetricLabels:
+  Enabled: true
+  Severity: warning

--- a/lib/rubocop/cop/sequra/prometheus_metric_labels.rb
+++ b/lib/rubocop/cop/sequra/prometheus_metric_labels.rb
@@ -1,0 +1,156 @@
+module RuboCop
+  module Cop
+    module Sequra
+      # Detects malformed label arguments on `prometheus_exporter` metric calls.
+      #
+      # `PrometheusExporter::Client::RemoteMetric` takes labels as a positional
+      # hash, and the position differs per method:
+      #
+      #   increment(keys = nil, value = 1)
+      #   decrement(keys = nil, value = 1)
+      #   observe(value = 1, keys = nil)
+      #
+      # None of them accept keyword arguments, so `increment(labels: {...})`
+      # does not raise. Ruby folds the keyword into the positional `keys` hash
+      # and the exporter emits a series carrying a label literally named
+      # `labels`, whose value is the stringified inner hash. The result is
+      # valid Prometheus exposition text, so the scrape succeeds and the
+      # target stays healthy — `sum by (outcome)` simply never matches.
+      #
+      # Nothing downstream can catch it: the exporter keys its series by the
+      # raw hash, `labels_text` interpolates label names without validating
+      # them, and `opts: { labels: [...] }` at registration is discarded
+      # outright for counters and gauges. There is no label schema anywhere,
+      # so a wrong label name is indistinguishable from a new one, and the
+      # mistake only surfaces when a query silently returns nothing.
+      #
+      # @example
+      #   # bad - folded into a label named "labels"
+      #   counter.increment(labels: { outcome: :bound })
+      #
+      #   # good
+      #   counter.increment({ outcome: :bound })
+      #
+      #   # bad - observe takes the value first
+      #   histogram.observe({ outcome: :ok }, duration)
+      #
+      #   # good
+      #   histogram.observe(duration, { outcome: :ok })
+      #
+      #   # bad - increment takes the labels first
+      #   counter.increment(1, { outcome: :bound })
+      #
+      #   # good
+      #   counter.increment({ outcome: :bound }, 1)
+      #
+      #   # bad - freezes the mistake into a passing spec
+      #   expect(counter).to receive(:increment).with(labels: { outcome: :bound })
+      #
+      #   # good
+      #   expect(counter).to receive(:increment).with({ outcome: :bound })
+      #
+      class PrometheusMetricLabels < Base
+        extend AutoCorrector
+
+        MSG_LABELS_KEYWORD = "Pass Prometheus labels positionally, not as a `labels:` keyword. " \
+                             "`increment`/`observe`/`decrement` take no keyword arguments, so this " \
+                             "becomes a single series labelled `labels=\"{...}\"` and by-label " \
+                             "queries never match. Use `increment({ outcome: :bound })`.".freeze
+
+        MSG_VALUE_FIRST = "`observe` takes the value first and the labels second: " \
+                          "`observe(value, { outcome: :ok })`. A labels hash in the first position " \
+                          "is recorded as the observed value.".freeze
+
+        MSG_LABELS_FIRST = "`%<method>s` takes the labels first and the value second: " \
+                           "`%<method>s({ outcome: :ok }, 1)`. This is the reverse of `observe`.".freeze
+
+        MSG_STUBBED_LABELS = "Stubbing `increment` with a `labels:` keyword asserts a label shape " \
+                             "prometheus_exporter never produces, so the spec stays green while " \
+                             "the metric is broken. Match the positional hash instead: " \
+                             "`.with({ outcome: :bound })`.".freeze
+
+        LABELS_FIRST_METHODS = [:increment, :decrement].freeze
+        VALUE_FIRST_METHODS = [:observe].freeze
+        METRIC_METHODS = (LABELS_FIRST_METHODS + VALUE_FIRST_METHODS).freeze
+
+        # `expect(counter).to receive(:increment).with(...)` and the
+        # `have_received` spy equivalent.
+        def_node_matcher :stubbed_metric_expectation?, <<~PATTERN
+          (send
+            (send nil? {:receive :have_received} (sym {:increment :decrement :observe}))
+            :with ...)
+        PATTERN
+
+        def on_send(node)
+          check_stubbed_labels_keyword(node)
+
+          return unless node.receiver && METRIC_METHODS.include?(node.method_name)
+
+          # A `labels:` key is the more specific diagnosis, so when it is
+          # present it wins and the positional checks stay quiet.
+          return if check_labels_keyword(node)
+
+          check_argument_order(node)
+        end
+
+        private
+
+        def check_labels_keyword(node)
+          pair = labels_pair(trailing_hash(node))
+          return false unless pair
+
+          register_labels_keyword_offense(node, pair, MSG_LABELS_KEYWORD)
+          true
+        end
+
+        def check_stubbed_labels_keyword(node)
+          return unless stubbed_metric_expectation?(node)
+
+          pair = labels_pair(trailing_hash(node))
+          return unless pair
+
+          register_labels_keyword_offense(node, pair, MSG_STUBBED_LABELS)
+        end
+
+        def check_argument_order(node)
+          arguments = node.arguments
+          return if arguments.empty?
+
+          if VALUE_FIRST_METHODS.include?(node.method_name)
+            add_offense(arguments.first, message: MSG_VALUE_FIRST) if arguments.first.hash_type?
+          elsif value_before_labels?(arguments)
+            add_offense(node, message: format(MSG_LABELS_FIRST, method: node.method_name))
+          end
+        end
+
+        # Only the unambiguous flip: a bare number where the labels belong,
+        # followed by the labels hash. Anything less literal than that could
+        # be a non-metric `increment` (`Rails.cache`, atomics) and is left
+        # alone.
+        def value_before_labels?(arguments)
+          arguments.size == 2 && arguments.first.numeric_type? && arguments.last.hash_type?
+        end
+
+        def trailing_hash(node)
+          last_argument = node.arguments.last
+          last_argument if last_argument&.hash_type?
+        end
+
+        def labels_pair(hash)
+          return unless hash
+
+          hash.pairs.find { |pair| pair.key.sym_type? && pair.key.value == :labels }
+        end
+
+        def register_labels_keyword_offense(node, pair, message)
+          add_offense(pair, message:) do |corrector|
+            # Unwrapping is only safe when `labels:` is the whole hash;
+            # with siblings present there is no single value to hoist.
+            hash = trailing_hash(node)
+            corrector.replace(hash, pair.value.source) if hash.pairs.one?
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/sequra_style.rb
+++ b/lib/sequra_style.rb
@@ -1,3 +1,4 @@
 require "rubocop"
 require_relative "rubocop/cop/sequra/async_job_pattern"
 require_relative "rubocop/cop/sequra/no_sidekiq_perform_stubs"
+require_relative "rubocop/cop/sequra/prometheus_metric_labels"

--- a/spec/rubocop/cop/sequra/prometheus_metric_labels_spec.rb
+++ b/spec/rubocop/cop/sequra/prometheus_metric_labels_spec.rb
@@ -1,0 +1,271 @@
+require "spec_helper"
+
+RSpec.describe RuboCop::Cop::Sequra::PrometheusMetricLabels, :config do
+  # Consumer repos are all on Ruby 3.2+, and real call sites use hash
+  # shorthand (`{ region:, outcome: }`), which RuboCop's default
+  # target of 2.7 cannot parse.
+  let(:ruby_version) { 3.4 }
+
+  let(:config) do
+    RuboCop::Config.new(
+      "Sequra/PrometheusMetricLabels" => {
+        "Enabled" => true,
+      }
+    )
+  end
+
+  context "with a `labels:` keyword" do
+    it "flags increment" do
+      expect_offense(<<~RUBY)
+        counter.increment(labels: { outcome: :bound })
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{described_class::MSG_LABELS_KEYWORD}
+      RUBY
+
+      expect_correction(<<~RUBY)
+        counter.increment({ outcome: :bound })
+      RUBY
+    end
+
+    it "flags decrement" do
+      expect_offense(<<~RUBY)
+        gauge.decrement(labels: { outcome: :bound })
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{described_class::MSG_LABELS_KEYWORD}
+      RUBY
+
+      expect_correction(<<~RUBY)
+        gauge.decrement({ outcome: :bound })
+      RUBY
+    end
+
+    it "flags observe" do
+      expect_offense(<<~RUBY)
+        histogram.observe(duration, labels: { outcome: :ok })
+                                    ^^^^^^^^^^^^^^^^^^^^^^^^ #{described_class::MSG_LABELS_KEYWORD}
+      RUBY
+
+      expect_correction(<<~RUBY)
+        histogram.observe(duration, { outcome: :ok })
+      RUBY
+    end
+
+    it "flags an explicitly braced hash, which parses identically" do
+      expect_offense(<<~RUBY)
+        counter.increment({ labels: { outcome: :bound } })
+                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{described_class::MSG_LABELS_KEYWORD}
+      RUBY
+
+      expect_correction(<<~RUBY)
+        counter.increment({ outcome: :bound })
+      RUBY
+    end
+
+    it "flags a variable passed under the keyword" do
+      expect_offense(<<~RUBY)
+        counter.increment(labels: metric_labels)
+                          ^^^^^^^^^^^^^^^^^^^^^ #{described_class::MSG_LABELS_KEYWORD}
+      RUBY
+
+      expect_correction(<<~RUBY)
+        counter.increment(metric_labels)
+      RUBY
+    end
+
+    it "flags a chained receiver" do
+      expect_offense(<<~RUBY)
+        Metrics.instance.request_counter.increment(labels: { outcome: :bound })
+                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{described_class::MSG_LABELS_KEYWORD}
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Metrics.instance.request_counter.increment({ outcome: :bound })
+      RUBY
+    end
+
+    it "flags a call site using hash shorthand values" do
+      expect_offense(<<~RUBY)
+        Metrics.instance.request_counter.increment(labels: { region:, outcome: })
+                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{described_class::MSG_LABELS_KEYWORD}
+      RUBY
+
+      expect_correction(<<~RUBY)
+        Metrics.instance.request_counter.increment({ region:, outcome: })
+      RUBY
+    end
+
+    it "flags but does not autocorrect when the keyword has siblings" do
+      expect_offense(<<~RUBY)
+        counter.increment(labels: { outcome: :bound }, by: 2)
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{described_class::MSG_LABELS_KEYWORD}
+      RUBY
+
+      expect_no_corrections
+    end
+  end
+
+  context "with flipped positional arguments" do
+    it "flags a labels hash in observe's value position" do
+      expect_offense(<<~RUBY)
+        histogram.observe({ outcome: :ok }, duration)
+                          ^^^^^^^^^^^^^^^^ #{described_class::MSG_VALUE_FIRST}
+      RUBY
+    end
+
+    it "flags a braceless hash as observe's only argument" do
+      expect_offense(<<~RUBY)
+        histogram.observe(outcome: :ok)
+                          ^^^^^^^^^^^^ #{described_class::MSG_VALUE_FIRST}
+      RUBY
+    end
+
+    it "flags a value before the labels on increment" do
+      expect_offense(<<~RUBY)
+        counter.increment(1, { outcome: :bound })
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(described_class::MSG_LABELS_FIRST, method: :increment)}
+      RUBY
+    end
+
+    it "flags a value before the labels on decrement" do
+      expect_offense(<<~RUBY)
+        gauge.decrement(2, { outcome: :bound })
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{format(described_class::MSG_LABELS_FIRST, method: :decrement)}
+      RUBY
+    end
+  end
+
+  context "with stubbed metric expectations" do
+    it "flags a `labels:` keyword on a message expectation" do
+      expect_offense(<<~RUBY)
+        expect(counter).to receive(:increment).with(labels: { region: "eu" })
+                                                    ^^^^^^^^^^^^^^^^^^^^^^^^ #{described_class::MSG_STUBBED_LABELS}
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(counter).to receive(:increment).with({ region: "eu" })
+      RUBY
+    end
+
+    it "flags a `labels:` keyword on a spy assertion" do
+      expect_offense(<<~RUBY)
+        expect(counter).to have_received(:observe).with(labels: { outcome: :ok })
+                                                        ^^^^^^^^^^^^^^^^^^^^^^^^ #{described_class::MSG_STUBBED_LABELS}
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(counter).to have_received(:observe).with({ outcome: :ok })
+      RUBY
+    end
+
+    it "flags a stub set up with allow" do
+      expect_offense(<<~RUBY)
+        allow(counter).to receive(:decrement).with(labels: { outcome: :bound })
+                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{described_class::MSG_STUBBED_LABELS}
+      RUBY
+
+      expect_correction(<<~RUBY)
+        allow(counter).to receive(:decrement).with({ outcome: :bound })
+      RUBY
+    end
+  end
+
+  context "with correct usage" do
+    it "accepts labels passed positionally" do
+      expect_no_offenses(<<~RUBY)
+        counter.increment({ outcome: :bound })
+      RUBY
+    end
+
+    it "accepts a braceless positional labels hash" do
+      expect_no_offenses(<<~RUBY)
+        counter.increment(outcome: :bound, region: "eu")
+      RUBY
+    end
+
+    it "accepts shorthand label values" do
+      expect_no_offenses(<<~RUBY)
+        counter.increment({ region:, outcome: })
+      RUBY
+    end
+
+    it "accepts labels then value on increment" do
+      expect_no_offenses(<<~RUBY)
+        counter.increment({ outcome: :bound }, 2)
+      RUBY
+    end
+
+    it "accepts value then labels on observe" do
+      expect_no_offenses(<<~RUBY)
+        histogram.observe(duration, { outcome: :ok })
+      RUBY
+    end
+
+    it "accepts observe with no labels" do
+      expect_no_offenses(<<~RUBY)
+        histogram.observe(Time.current - started_at)
+      RUBY
+    end
+
+    it "accepts increment with no arguments" do
+      expect_no_offenses(<<~RUBY)
+        counter.increment
+      RUBY
+    end
+
+    it "accepts a positional labels variable" do
+      expect_no_offenses(<<~RUBY)
+        counter.increment(metric_labels)
+      RUBY
+    end
+
+    it "accepts an unrelated label named similarly" do
+      expect_no_offenses(<<~RUBY)
+        counter.increment({ label_set: :bound })
+      RUBY
+    end
+
+    it "accepts a message expectation on the positional hash" do
+      expect_no_offenses(<<~RUBY)
+        expect(counter).to receive(:increment).with({ region: "eu" })
+      RUBY
+    end
+
+    it "accepts a bare message expectation" do
+      expect_no_offenses(<<~RUBY)
+        expect(counter).to receive(:increment)
+      RUBY
+    end
+  end
+
+  context "with non-metric receivers" do
+    it "accepts Rails cache increment with options" do
+      expect_no_offenses(<<~RUBY)
+        Rails.cache.increment(new_session_count_key, 1, expires_in: TTL)
+      RUBY
+    end
+
+    it "accepts Rails cache increment without an explicit amount" do
+      expect_no_offenses(<<~RUBY)
+        Rails.cache.increment(key, expires_in: TTL)
+      RUBY
+    end
+
+    it "accepts an atomic counter increment" do
+      expect_no_offenses(<<~RUBY)
+        atomic_counter.increment(5)
+      RUBY
+    end
+
+    it "accepts a method definition named increment" do
+      expect_no_offenses(<<~RUBY)
+        def self.increment(labels)
+          labels
+        end
+      RUBY
+    end
+
+    it "accepts an unrelated method taking a labels keyword" do
+      expect_no_offenses(<<~RUBY)
+        chart.render(labels: { outcome: :bound })
+      RUBY
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require "rubocop/rspec/support"
 
 require_relative "../lib/rubocop/cop/sequra/async_job_pattern"
 require_relative "../lib/rubocop/cop/sequra/no_sidekiq_perform_stubs"
+require_relative "../lib/rubocop/cop/sequra/prometheus_metric_labels"
 
 RSpec.configure do |config|
   config.include(RuboCop::RSpec::ExpectOffense)


### PR DESCRIPTION
### What is the goal?

`prometheus_exporter` metrics take their labels as a positional hash, and no method on them accepts keyword arguments. So `counter.increment(labels: { outcome: :ok })` does not raise — Ruby folds the keyword into the positional hash and the exporter emits one series carrying a label literally named `labels`, holding a stringified Ruby hash. The exposition text stays valid, the scrape succeeds, and nothing looks broken until a `sum by (outcome)` query returns nothing.

This cop catches that at lint time, plus the related argument-order trap: `increment` takes the labels first, `observe` takes the value first.

### Is this a restricting or expanding change?

**RESTRICTING change**, at `warning` severity, so offenses fail the build.

The template suggests `info` for restricting changes to allow adoption time. Deliberately not doing that here: these offenses are silently broken metrics rather than a style preference, and every one found so far was a real defect. Letting them accumulate behind a non-failing severity is how the bug survives.

### How is it being implemented?

- Flags a `labels:` key in the hash argument of `increment`, `decrement` and `observe`, and autocorrects it to the positional hash.
- Flags the reversed argument order, limited to unambiguous literals so unrelated `increment` methods (caches, atomic counters) are left alone.
- Flags the same mistake in RSpec message expectations (`receive(:increment).with(labels: ...)`), which otherwise assert the broken shape and keep a spec green while the metric is broken.

### How is it tested?

Automated tests. Also run against two large consumer codebases: it flagged 10 genuine offenses, two separate live cases of the bug, with no false positives across ~17,000 files.

### Caveats

Consumers will need to fix their existing offenses (or grandfather them in `.rubocop_todo.yml`) when they pick up this version, since the cop fails the build. Every offense found so far is autocorrectable except where `labels:` sits alongside other keys, which needs a human decision about the intended metric.