### PR TITLE
feat: [COR-1992] Flag mailer .later stubs in NoSidekiqPerformStubs

### DIFF
--- a/lib/rubocop/cop/sequra/no_sidekiq_perform_stubs.rb
+++ b/lib/rubocop/cop/sequra/no_sidekiq_perform_stubs.rb
@@ -2,7 +2,8 @@ module RuboCop
   module Cop
     module Sequra
       # Detects RSpec stubs and spy assertions on Sidekiq enqueue methods
-      # (`perform_async`, `perform_at`, `perform_in`).
+      # (`perform_async`, `perform_at`, `perform_in`) and on the mailer
+      # enqueue wrapper (`SomeMailer.later`).
       #
       # Stubbing these methods bypasses `Sidekiq.strict_args!` validation,
       # which lets symbol-keyed hashes (and other non-JSON-native types)
@@ -12,12 +13,19 @@ module RuboCop
       # rescue-swallowers can mask the failure. This pattern caused a
       # silent push-notification drop in COR-1923.
       #
+      # `SomeMailer.later` (seQura's `ApplicationMailer.later`) is the
+      # standard mailer enqueue path and funnels through
+      # `ApplicationMailerJob.perform_async`, so stubbing it bypasses
+      # `strict_args!` exactly like stubbing `perform_async` directly.
+      # `.later` is only flagged when the stubbed subject is a `*Mailer`
+      # constant, so unrelated `.later` methods are left alone.
+      #
       # Use `have_enqueued_sidekiq_job` (or `change(SomeJob.jobs, :size)`)
       # instead. Both go through Sidekiq's client middleware chain, so
       # `strict_args!` validates the arguments as it would in production.
       #
       # `.and_call_original` is exempt: the stub spies on the call but
-      # then runs the real `perform_*`, which still exercises the
+      # then runs the real method, which still exercises the
       # serialization contract.
       #
       # @example
@@ -33,6 +41,9 @@ module RuboCop
       #   # bad - spy verification on a stubbed enqueue
       #   expect(SomeJob).to have_received(:perform_async).with(id)
       #
+      #   # bad - mailer enqueue wrapper bypasses strict_args! too
+      #   allow(WelcomeMailer).to receive(:later)
+      #
       #   # good - exercises strict_args! through Sidekiq's middleware
       #   expect(SomeJob).to have_enqueued_sidekiq_job(id, name: "value")
       #
@@ -43,23 +54,49 @@ module RuboCop
       #   expect(SomeJob).to receive(:perform_async).and_call_original
       #
       class NoSidekiqPerformStubs < Base
-        MSG = "Avoid stubbing Sidekiq enqueue methods (`perform_async`/`perform_at`/`perform_in`). " \
-              "Stubs bypass `Sidekiq.strict_args!` validation and can hide symbol-keyed hash bugs " \
-              "(see COR-1923). Use `have_enqueued_sidekiq_job` or `change(Job.jobs, :size)` instead. " \
-              "Use `.and_call_original` only as an escape hatch.".freeze
+        MSG = "Avoid stubbing job/mailer enqueue methods (`perform_async`/`perform_at`/`perform_in`, " \
+              "or `Mailer.later`). Stubs bypass `Sidekiq.strict_args!` validation and can hide " \
+              "symbol-keyed hash bugs (see COR-1923). Use `have_enqueued_sidekiq_job` or " \
+              "`change(Job.jobs, :size)` instead. Use `.and_call_original` only as an escape hatch.".freeze
+
+        SUBJECT_WRAPPERS = [:allow, :expect, :allow_any_instance_of, :expect_any_instance_of].freeze
 
         def_node_matcher :perform_method_stub?, <<~PATTERN
           (send nil? {:receive :have_received} (sym {:perform_async :perform_at :perform_in}))
         PATTERN
 
+        def_node_matcher :later_method_stub?, <<~PATTERN
+          (send nil? {:receive :have_received} (sym :later))
+        PATTERN
+
         def on_send(node)
-          return unless perform_method_stub?(node)
+          return unless perform_method_stub?(node) || mailer_later_stub?(node)
           return if chained_with_call_original?(node)
 
           add_offense(node)
         end
 
         private
+
+        def mailer_later_stub?(node)
+          return false unless later_method_stub?(node)
+
+          subject = stubbed_subject(node)
+          subject&.const_type? && subject.const_name.to_s.end_with?("Mailer")
+        end
+
+        def stubbed_subject(node)
+          current = node
+          current = current.parent while current.parent&.send_type? && current.parent.receiver == current
+
+          matcher = current.parent
+          return unless matcher&.send_type?
+
+          wrapper = matcher.receiver
+          return unless wrapper&.send_type? && SUBJECT_WRAPPERS.include?(wrapper.method_name)
+
+          wrapper.first_argument
+        end
 
         def chained_with_call_original?(node)
           current = node

--- a/spec/rubocop/cop/sequra/no_sidekiq_perform_stubs_spec.rb
+++ b/spec/rubocop/cop/sequra/no_sidekiq_perform_stubs_spec.rb
@@ -143,6 +143,54 @@ RSpec.describe RuboCop::Cop::Sequra::NoSidekiqPerformStubs, :config do
     end
   end
 
+  context "with mailer `.later` enqueue stubs" do
+    it "flags `allow(SomeMailer).to receive(:later)`" do
+      expect_offense(<<~RUBY)
+        allow(WelcomeMailer).to receive(:later)
+                                ^^^^^^^^^^^^^^^ #{described_class::MSG}
+      RUBY
+    end
+
+    it "flags namespaced mailer constants" do
+      expect_offense(<<~RUBY)
+        allow(AffiliateNetwork::Prime::IntegrationDocumentationMailer).to receive(:later)
+                                                                          ^^^^^^^^^^^^^^^ #{described_class::MSG}
+      RUBY
+    end
+
+    it "flags `.later` with chained `.with(args)`" do
+      expect_offense(<<~RUBY)
+        expect(WelcomeMailer).to have_received(:later).with(:welcome, user)
+                                 ^^^^^^^^^^^^^^^^^^^^^ #{described_class::MSG}
+      RUBY
+    end
+
+    it "flags negative expectation on `.later`" do
+      expect_offense(<<~RUBY)
+        expect(WelcomeMailer).not_to receive(:later)
+                                     ^^^^^^^^^^^^^^^ #{described_class::MSG}
+      RUBY
+    end
+
+    it "does not flag `.later` on a non-mailer constant" do
+      expect_no_offenses(<<~RUBY)
+        allow(SomeScheduler).to receive(:later)
+      RUBY
+    end
+
+    it "does not flag `.later` on a non-constant subject" do
+      expect_no_offenses(<<~RUBY)
+        allow(scheduler).to receive(:later)
+      RUBY
+    end
+
+    it "does not flag mailer `.later` with `.and_call_original`" do
+      expect_no_offenses(<<~RUBY)
+        allow(WelcomeMailer).to receive(:later).and_call_original
+      RUBY
+    end
+  end
+
   context "with `.and_call_original` escape hatch" do
     it "does not flag `receive(:perform_async).and_call_original`" do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
### What is the goal?

`Sequra/NoSidekiqPerformStubs` was meant to stop specs from stubbing an enqueue and thereby bypassing `Sidekiq.strict_args!` (which is what hides symbol-keyed-hash bugs, per COR-1923). But it only matched `perform_async`/`perform_at`/`perform_in`. Mailers in our codebase don't enqueue via `perform_async` — they use `SomeMailer.later` (seQura's `ApplicationMailer.later`), the standard path with 130+ call sites. Stubbing `.later` bypasses `strict_args!` just the same, and the cop stayed silent.

This gap let a real production incident through: SIMBA-5Z4 — a symbol-keyed hash passed to a mailer `.later` raised `ArgumentError` at enqueue, but the operation's spec stubbed `.later`, so CI was green.

### Is this a restricting or expanding change?

**RESTRICTING change**

Adds `.later` to the methods the cop flags. Scoped tightly: `.later` is only flagged when the stubbed subject is a `*Mailer` constant, so unrelated `.later` methods are untouched. The cop is `Enabled: false` by default (opt-in per repo), so this only affects repos that already turned it on.

### References
* **Related pull-requests:** #70 (original cop, COR-1992)
* **Any other references:** https://sequra.sentry.io/issues/7637718463/ (SIMBA-5Z4)

### How is it being implemented?

- New `later_method_stub?` matcher plus a `mailer_later_stub?` guard that walks up to the enclosing `allow`/`expect`/`allow_any_instance_of`/`expect_any_instance_of` and checks the subject is a `*Mailer` constant.
- `.and_call_original` remains the escape hatch, unchanged.
- MSG and cop docs updated to mention the mailer path.
- Added positive specs (bare, namespaced, `have_received().with`, negative expectation) and negatives (non-mailer const, non-const subject, `.and_call_original`).

### How is it tested?

Automated tests (cop spec, 38 examples).
