### PR TITLE
fix(rubocop): don't flag wrapper observe kwargs as misplaced labels

### DIFF
--- a/lib/rubocop/cop/sequra/prometheus_metric_labels.rb
+++ b/lib/rubocop/cop/sequra/prometheus_metric_labels.rb
@@ -37,6 +37,10 @@ module RuboCop
       #   # good
       #   histogram.observe(duration, { outcome: :ok })
       #
+      #   # allowed - a lone braceless hash is keyword-argument syntax, which
+      #   # `RemoteMetric#observe` does not accept, so this is a wrapper call
+      #   histogram_wrapper.observe(score: 0.87, match: true)
+      #
       #   # bad - increment takes the labels first
       #   counter.increment(1, { outcome: :bound })
       #
@@ -117,10 +121,24 @@ module RuboCop
           return if arguments.empty?
 
           if VALUE_FIRST_METHODS.include?(node.method_name)
-            add_offense(arguments.first, message: MSG_VALUE_FIRST) if arguments.first.hash_type?
+            add_offense(arguments.first, message: MSG_VALUE_FIRST) if labels_in_value_position?(arguments)
           elsif value_before_labels?(arguments)
             add_offense(node, message: format(MSG_LABELS_FIRST, method: node.method_name))
           end
+        end
+
+        # Only the unambiguous cases: the value follows the hash, or braces
+        # mark the hash as a deliberate positional argument. A lone braceless
+        # hash is keyword-argument syntax, and since `RemoteMetric#observe`
+        # takes no keywords it cannot be one of its call sites — it is how a
+        # wrapper around a metric is invoked (`histogram.observe(score:,
+        # match:)`), so flagging it hits every such wrapper rather than the
+        # mistake.
+        def labels_in_value_position?(arguments)
+          first_argument = arguments.first
+          return false unless first_argument.hash_type?
+
+          arguments.size > 1 || first_argument.braces?
         end
 
         # Only the unambiguous flip: a bare number where the labels belong,

--- a/spec/rubocop/cop/sequra/prometheus_metric_labels_spec.rb
+++ b/spec/rubocop/cop/sequra/prometheus_metric_labels_spec.rb
@@ -110,10 +110,10 @@ RSpec.describe RuboCop::Cop::Sequra::PrometheusMetricLabels, :config do
       RUBY
     end
 
-    it "flags a braceless hash as observe's only argument" do
+    it "flags a braced hash as observe's only argument" do
       expect_offense(<<~RUBY)
-        histogram.observe(outcome: :ok)
-                          ^^^^^^^^^^^^ #{described_class::MSG_VALUE_FIRST}
+        histogram.observe({ outcome: :ok })
+                          ^^^^^^^^^^^^^^^^ #{described_class::MSG_VALUE_FIRST}
       RUBY
     end
 
@@ -265,6 +265,30 @@ RSpec.describe RuboCop::Cop::Sequra::PrometheusMetricLabels, :config do
     it "accepts an unrelated method taking a labels keyword" do
       expect_no_offenses(<<~RUBY)
         chart.render(labels: { outcome: :bound })
+      RUBY
+    end
+
+    it "accepts a wrapper whose observe takes keyword arguments" do
+      expect_no_offenses(<<~RUBY)
+        Instrumentation::CardholderNameMatchHistogram.new.observe(
+          score: result.score,
+          match: result.match,
+          reason: result.reason
+        )
+      RUBY
+    end
+
+    it "accepts a wrapper observe call using hash shorthand" do
+      expect_no_offenses(<<~RUBY)
+        histogram_wrapper.observe(score:, match:, reason:)
+      RUBY
+    end
+
+    it "accepts a wrapper observe definition delegating positionally" do
+      expect_no_offenses(<<~RUBY)
+        def observe(score:, match:, reason:)
+          histogram.observe(score, { match:, reason: })
+        end
       RUBY
     end
   end


### PR DESCRIPTION
### What is the goal?

The new `Sequra/PrometheusMetricLabels` cop flags any hash in the first
position of an `observe` call. That also catches calls to wrapper classes
whose own `observe` takes keyword arguments, which are correct code. In
payments-gateway this produces 4 offences and blocks the 1.18.0 bump.

### Is this a restricting or expanding change?

**EXPANDING change** — it removes one shape from what the cop reports.

### References

* **Related pull-requests:** #79

### How is it being implemented?

- A hash in `observe`'s value position is now only reported when the value
  follows it (`observe({ outcome: :ok }, duration)`) or when braces mark it as
  a deliberate positional hash (`observe({ outcome: :ok })`).
- A lone braceless hash is keyword-argument syntax. `RemoteMetric#observe`
  accepts no keywords, so that shape can never be one of its call sites — only
  a wrapper's. This mirrors the caution `value_before_labels?` already applies
  to `increment`/`decrement` to avoid non-metric receivers.

### Caveats

`histogram.observe(outcome: :ok)` on a real metric is no longer reported. That
shape is indistinguishable from a wrapper call without cross-file type
information, and the false positives outnumbered it.
